### PR TITLE
Make `get_ir_reciprocal_mesh` & `get_stabilized_reciprocal_mesh` return mapping with index starting from 1, not 0

### DIFF
--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -70,6 +70,7 @@ function get_ir_reciprocal_mesh(
         symprec,
     )
     @assert num_ir > 0 "Something wrong happens when finding mesh!"
+    grid_mapping_table .+= 1  # See https://github.com/singularitti/Spglib.jl/issues/56
     return num_ir, grid_mapping_table, grid_address
 end
 
@@ -113,5 +114,6 @@ function get_stabilized_reciprocal_mesh(
         qpoints,
     )
     @assert exitcode > 0 "Something wrong happens when finding mesh!"
+    mapping .+= 1  # See https://github.com/singularitti/Spglib.jl/issues/56
     return mapping, grid_address
 end

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -20,6 +20,9 @@ irreducible points are returned as `grid_mapping_table` as in the indices of
 `grid_address`. The number of the irreducible k-points are
 returned as the return value. The time reversal symmetry is
 imposed by setting `is_time_reversal`.
+
+!!! compat "Version 0.2"
+    The returned mapping table is indexed starting at `1`, not `0` as in Python or C.
 """
 function get_ir_reciprocal_mesh(
     cell::Cell,

--- a/test/reciprocal.jl
+++ b/test/reciprocal.jl
@@ -1,11 +1,13 @@
 function list_points(mapping, grid, mesh, shift, ir_only)
-    # `unique(mapping)` and `mapping` are irreducible points and all points, respectively. They have different shapes.
-    if ir_only
-        mapping = unique(mapping)  # Cannot use `unique!(mapping)`, it will change future results
-    end
     shift = shift ./ 2  # true / 2 = 0.5, false / 2 = 0
-    return map(mapping) do id
-        (grid[:, id+1] .+ shift) ./ mesh  # Add 1 because `mapping` index starts from 0
+    if ir_only
+        return map(unique(mapping)) do i
+            (grid[:, i] .+ shift) ./ mesh
+        end
+    else
+        return map(eachslice(grid; dims = 2)) do point
+            (point .+ shift) ./ mesh  # Add 1 because `mapping` index starts from 0
+        end
     end
 end
 
@@ -563,7 +565,7 @@ end
             15,
             1,
         ]
-        @test ir_mapping_table == python_mapping
+        @test ir_mapping_table == python_mapping .+ 1
         @test nir == 29
         # Irreducible k-points
         python_results = [
@@ -1124,7 +1126,7 @@ end
             1,
             0,
         ]
-        @test ir_mapping_table == python_mapping
+        @test ir_mapping_table == python_mapping .+ 1
         @test nir == 60
         # Irreducible k-points
         python_results = [


### PR DESCRIPTION
Closes #56