### PR TITLE
Fix type-instability in `lattice`-field of `Cell`

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -17,7 +17,7 @@ The collinear polarizations `magmoms` only work with `get_symmetry` and are give
 as a list of ``N`` floating point values.
 """
 struct Cell{N,L,P,T,M}
-    lattice::MMatrix{3,3,L}
+    lattice::MMatrix{3,3,L,9}
     positions::MMatrix{3,N,P}
     types::MVector{N,T}
     magmoms::MVector{N,M}


### PR DESCRIPTION
`MMatrix{3,3,L}` is not a concrete type, unfortunately. I figured I'd suggest changing this so inference of `getfield(::Cell, :lattice)` isn't poisoned.

The same problem affects the `positions` but it cannot be fixed simply while retaining the `MMatrix` approach cf. https://github.com/JuliaLang/julia/issues/18466: personally, I think it'd make more sense to treat that as a `Vector{MVector{3,P}}` - it doesn't seem worthwhile to specialize to how many atoms are in a cell. Anyway, that is a larger change and I just wanted to do the minimal change here.