### PR TITLE
Use show instead of display when overriding show

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -140,10 +140,12 @@ end
 function Base.show(io::IO, cell::Cell{N}) where {N}
     println(io, "lattice:")
     print(io, " ")
-    display(cell.lattice)
+    show(io, "text/plain", cell.lattice)
+    println(io, "")
     println(io, "$N atomic positions:")
     print(io, " ")
-    display(cell.positions)
+    show(io, "text/plain", cell.positions)
+    println(io, "")
     println(io, "$N atoms:")
     println(io, " ", cell.types)
 end


### PR DESCRIPTION
Hi, thanks for developing this very nice package!

I noticed that when cell is printed by a logging macro, the output is not well formatted (see below). I found that using `show(io, "text/plain", cell.lattice)` instead of `display(cell.lattice)` fixes the issue.

Before:
```julia
julia> @info cell
3×3 StaticArrays.MMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 5.07598  -2.82803  0.0
 5.07598   2.82803  0.0
 0.0       0.0      8.57155
3×8 StaticArrays.MMatrix{3, 8, Float64, 24} with indices SOneTo(3)×SOneTo(8):
 0.0       0.0       0.0       0.0       0.5       0.5       0.5       0.5
 0.846884  0.653116  0.346884  0.153116  0.346884  0.153116  0.846884  0.653116
 0.120313  0.620313  0.379687  0.879687  0.120313  0.620313  0.379687  0.879687
┌ Info: lattice:
│  8 atomic positions:
│  8 atoms:
└  [35, 35, 35, 35, 35, 35, 35, 35]
```

After:
```julia
julia> @info cell
┌ Info: lattice:
│  3×3 StaticArrays.MMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
│  5.07598  -2.82803  0.0
│  5.07598   2.82803  0.0
│  0.0       0.0      8.57155
│ 8 atomic positions:
│  3×8 StaticArrays.MMatrix{3, 8, Float64, 24} with indices SOneTo(3)×SOneTo(8):
│  0.0       0.0       0.0       0.0       0.5       0.5       0.5       0.5
│  0.846884  0.653116  0.346884  0.153116  0.346884  0.153116  0.846884  0.653116
│  0.120313  0.620313  0.379687  0.879687  0.120313  0.620313  0.379687  0.879687
│ 8 atoms:
└  [35, 35, 35, 35, 35, 35, 35, 35]
```