### PR TITLE
Fix bug in niggli_reduce

### DIFF
--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -21,7 +21,10 @@ end
 function niggli_reduce(cell::Cell, symprec = 1e-5)
     lattice = cell.lattice
     clattice = niggli_reduce(lattice, symprec)
-    return Cell(clattice, cell.positions, cell.types, cell.magmoms)
+    # Keeping cartesian coordinates
+    recip = inv(clattice) * cell.lattice 
+    new_frac_pos = [recip * pos for pos in cell.positions]
+    return Cell(clattice, new_frac_pos, cell.types, cell.magmoms)
 end
 
 """
@@ -47,5 +50,8 @@ end
 function delaunay_reduce(cell::Cell, symprec = 1e-5)
     lattice = cell.lattice
     clattice = delaunay_reduce(lattice, symprec)
-    return Cell(clattice, cell.positions, cell.types, cell.magmoms)
+    # Keeping cartesian coordinates
+    recip = inv(clattice) * cell.lattice 
+    new_frac_pos = [recip * pos for pos in cell.positions]
+    return Cell(clattice, new_frac_pos, cell.types, cell.magmoms)
 end

--- a/src/standardize.jl
+++ b/src/standardize.jl
@@ -39,7 +39,7 @@ function standardize_cell(
         throw(SpglibError("Cell standardization failed!"))
     end
     # We have to `transpose` back because of `_expand_cell`!
-    return Cell(transpose(lattice), _positions[:, 1:num_atom_std], _types[1:num_atom_std])
+    return Cell(transpose(lattice), collect(eachcol(_positions))[1:num_atom_std], _types[1:num_atom_std])
 end
 
 """

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -20,7 +20,7 @@ function get_symmetry(
     max_size = length(cell.types) * 48
     rotation = Array{Cint,3}(undef, 3, 3, max_size)
     translation = Array{Cdouble,2}(undef, 3, max_size)
-    if iszero(cell.magmoms)
+    if isnothing(cell.magmoms) || iszero(cell.magmoms)
         return get_symmetry!(rotation, translation, cell, symprec)
     else
         equivalent_atoms = zeros(length(cell.magmoms))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -10,6 +10,12 @@
         -2.0 0.0 0.0
         0.0 0.0 12.0
     ]
+    cell = Cell(lattice, [[0., 0., 0.], [0.05, 0.05, 0.05]], [1, 1])
+    rcell = niggli_reduce(cell)
+    c1 = Ref(cell.lattice) .* cell.positions 
+    c2 = Ref(rcell.lattice) .* rcell.positions 
+    # Cartesian coordinates should remain the same
+    @test c1 == c2
 end
 # From https://github.com/unkcpz/LibSymspg.jl/blob/f342e72/test/runtests.jl#L87-89
 @testset "Delaunay reduce" begin
@@ -23,4 +29,10 @@ end
         2.0 0.0 0.0
         0.0 0.0 12.0
     ]
+    cell = Cell(lattice, [[0., 0., 0.], [0.05, 0.05, 0.05]], [1, 1])
+    rcell = niggli_reduce(cell)
+    c1 = Ref(cell.lattice) .* cell.positions 
+    c2 = Ref(rcell.lattice) .* rcell.positions 
+    # Cartesian coordinates should remain the same
+    @test c1 == c2
 end


### PR DESCRIPTION
Reduction should keep cartesian coordinates unchanged not the fractional ones. 
Fix #106 

Also fix standardize_cell which did not work for 3-atom cell due to ambigious position matrix.

Fix for get_symmetry when `Cell.magmom` is `nothing`.