### PR TITLE
Rename `SpglibError` to `SpglibReturnCode` to better match its usage

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -1,4 +1,4 @@
-export get_error_code, get_error_message
+export get_error_code, get_error_message, check_error
 
 # See https://www.mcobject.com/docs/Content/Programming/C/Return_Codes.htm or
 # https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
@@ -15,8 +15,24 @@ export get_error_code, get_error_message
     NONE
 end
 
+struct SpglibError <: Exception
+    msg::String
+end
+
 get_error_code() = ccall((:spg_get_error_code, libsymspg), SpglibReturnCode, ())
 
 get_error_message(spglib_error::SpglibReturnCode) = unsafe_string(
     ccall((:spg_get_error_message, libsymspg), Cstring, (SpglibReturnCode,), spglib_error),
 )
+
+function check_error()
+    code = get_error_code()
+    if code == SUCCESS
+        return nothing
+    else
+        return throw(SpglibError(get_error_message(code)))
+    end
+end
+
+# See https://github.com/JuliaLang/julia/blob/3903fa5/base/missing.jl#L18-L19
+Base.showerror(io::IO, ex::SpglibError) = print(io, "SpglibError: ", ex.msg, '!')

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,20 +1,22 @@
 export get_error_code, get_error_message
 
-@enum SpglibError begin
-    SPGLIB_SUCCESS = 0
-    SPGERR_SPACEGROUP_SEARCH_FAILED
-    SPGERR_CELL_STANDARDIZATION_FAILED
-    SPGERR_SYMMETRY_OPERATION_SEARCH_FAILED
-    SPGERR_ATOMS_TOO_CLOSE
-    SPGERR_POINTGROUP_NOT_FOUND
-    SPGERR_NIGGLI_FAILED
-    SPGERR_DELAUNAY_FAILED
-    SPGERR_ARRAY_SIZE_SHORTAGE
-    SPGERR_NONE
+# See https://www.mcobject.com/docs/Content/Programming/C/Return_Codes.htm or
+# https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
+@enum SpglibReturnCode begin
+    SUCCESS  # 0
+    SPACEGROUP_SEARCH_FAILED
+    CELL_STANDARDIZATION_FAILED
+    SYMMETRY_OPERATION_SEARCH_FAILED
+    ATOMS_TOO_CLOSE
+    POINTGROUP_NOT_FOUND
+    NIGGLI_FAILED
+    DELAUNAY_FAILED
+    ARRAY_SIZE_SHORTAGE
+    NONE
 end
 
-get_error_code() = ccall((:spg_get_error_code, libsymspg), SpglibError, ())
+get_error_code() = ccall((:spg_get_error_code, libsymspg), SpglibReturnCode, ())
 
-get_error_message(spglib_error::SpglibError) = unsafe_string(
-    ccall((:spg_get_error_message, libsymspg), Cstring, (SpglibError,), spglib_error)
+get_error_message(spglib_error::SpglibReturnCode) = unsafe_string(
+    ccall((:spg_get_error_message, libsymspg), Cstring, (SpglibReturnCode,), spglib_error),
 )

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -68,9 +68,7 @@ function get_ir_reciprocal_mesh(
         num_atom,
         symprec,
     )
-    if nir <= 0
-        throw(SpglibError("Something wrong happens when finding mesh!"))
-    end
+    check_error()
     grid_mapping_table .+= 1  # See https://github.com/singularitti/Spglib.jl/issues/56
     return nir, grid_mapping_table, grid_address
 end
@@ -110,9 +108,7 @@ function get_stabilized_reciprocal_mesh(
         length(qpoints),
         qpoints,
     )
-    if nir <= 0
-        throw(SpglibError("Something wrong happens when finding mesh!"))
-    end
+    check_error()
     mapping .+= 1  # See https://github.com/singularitti/Spglib.jl/issues/56
     return nir, mapping, grid_address
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -6,12 +6,8 @@ Apply Niggli reduction to input basis vectors `lattice`.
 """
 function niggli_reduce(lattice::AbstractMatrix, symprec=1e-5)
     clattice = convert(Matrix{Cdouble}, transpose(lattice))
-    exitcode = ccall(
-        (:spg_niggli_reduce, libsymspg), Cint, (Ptr{Cdouble}, Cdouble), clattice, symprec
-    )
-    if exitcode == 0
-        throw(SpglibError("Niggli reduce failed!"))
-    end
+    ccall((:spg_niggli_reduce, libsymspg), Cint, (Ptr{Cdouble}, Cdouble), clattice, symprec)
+    check_error()
     return transpose(clattice)
 end
 function niggli_reduce(cell::Cell, symprec=1e-5)
@@ -31,12 +27,10 @@ Apply Delaunay reduction to input basis vectors `lattice`.
 """
 function delaunay_reduce(lattice::AbstractMatrix, symprec=1e-5)
     clattice = convert(Matrix{Cdouble}, transpose(lattice))
-    exitcode = ccall(
+    ccall(
         (:spg_delaunay_reduce, libsymspg), Cint, (Ptr{Cdouble}, Cdouble), clattice, symprec
     )
-    if exitcode == 0
-        throw(SpglibError("Delaunay reduce failed!"))
-    end
+    check_error()
     return transpose(clattice)
 end
 function delaunay_reduce(cell::Cell, symprec=1e-5)

--- a/src/standardize.jl
+++ b/src/standardize.jl
@@ -30,9 +30,7 @@ function standardize_cell(cell::Cell; to_primitive=false, no_idealize=false, sym
         no_idealize,
         symprec,
     )  # Note: not `num_atom`!
-    if num_atom_std <= 0
-        throw(SpglibError("Cell standardization failed!"))
-    end
+    check_error()
     # We have to `transpose` back because of `_expand_cell`!
     return Cell(
         transpose(lattice),

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -55,9 +55,7 @@ function get_symmetry(cell::Cell, symprec=1e-5, angle_tolerance=-1.0, is_magneti
             symprec,
             angle_tolerance,
         )
-        if num_sym == 0
-            throw(SpglibError("Symmetry operation search failed!"))
-        end
+        check_error()
         return rotation[:, :, 1:num_sym],
         translation[:, 1:num_sym], equivalent_atoms,
         primitive_lattice
@@ -100,9 +98,7 @@ function get_symmetry!(
         num_atom,
         symprec,
     )
-    if num_sym == 0
-        throw(SpglibError("Symmetry operation search failed!"))
-    end
+    check_error()
     return rotation[:, :, 1:num_sym], translation[:, 1:num_sym]
 end
 
@@ -146,9 +142,7 @@ function get_symmetry_with_collinear_spin!(
         num_atom,
         symprec,
     )
-    if num_sym == 0
-        throw(SpglibError("Symmetry operation search failed!"))
-    end
+    check_error()
     return num_sym
 end
 function get_symmetry_with_collinear_spin(cell::Cell, symprec=1e-5)
@@ -202,9 +196,7 @@ function get_symmetry_from_database!(
         translation,
         hall_number,
     )
-    if num_sym == 0
-        throw(SpglibError("Symmetry operation search failed!"))
-    end
+    check_error()
     return rotation[:, :, 1:num_sym], translation[:, 1:num_sym]
 end
 
@@ -283,9 +275,7 @@ function get_multiplicity(cell::Cell, symprec=1e-5)
         num_atom,
         symprec,
     )
-    if num_sym == 0
-        throw(SpglibError("Symmetry operation search failed!"))
-    end
+    check_error()
     return num_sym
 end
 
@@ -382,7 +372,7 @@ Return the space group type in Hermann–Mauguin (international) notation.
 function get_international(cell::Cell, symprec=1e-5)
     lattice, positions, types = _expand_cell(cell)
     symbol = Vector{Cchar}(undef, 11)
-    exitcode = ccall(
+    ccall(
         (:spg_get_international, libsymspg),
         Cint,
         (Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Cint, Cdouble),
@@ -393,9 +383,7 @@ function get_international(cell::Cell, symprec=1e-5)
         length(types),
         symprec,
     )
-    if exitcode == 0
-        throw(SpglibError("Spacegroup search failed!"))
-    end
+    check_error()
     return cchars2string(symbol)
 end
 
@@ -407,7 +395,7 @@ Return the space group type in Schoenflies notation.
 function get_schoenflies(cell::Cell, symprec=1e-5)
     lattice, positions, types = _expand_cell(cell)
     symbol = Vector{Cchar}(undef, 7)
-    exitcode = ccall(
+    ccall(
         (:spg_get_schoenflies, libsymspg),
         Cint,
         (Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Cint, Cdouble),
@@ -418,8 +406,6 @@ function get_schoenflies(cell::Cell, symprec=1e-5)
         length(types),
         symprec,
     )
-    if exitcode == 0
-        throw(SpglibError("Spacegroup search failed!"))
-    end
+    check_error()
     return cchars2string(symbol)
 end


### PR DESCRIPTION
Recover `SpglibError` type removed from #115 & add `check_error`