### PR TITLE
Improve the performance of `_expand_cell` even further by removing all type instabilities

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -153,22 +153,18 @@ Lattice(cell::SpglibCell) = cell.lattice
 
 # This is an internal function, do not export!
 function _expand_cell(cell::SpglibCell)
-    lattice, positions, atoms, magmoms = cell.lattice,
-    cell.positions, cell.atoms,
-    cell.magmoms
+    lattice, positions, atoms, magmoms = cell.lattice, cell.positions, cell.atoms, cell.magmoms
     # Reference: https://github.com/mdavezac/spglib.jl/blob/master/src/spglib.jl#L32-L35 and https://github.com/spglib/spglib/blob/444e061/python/spglib/spglib.py#L953-L975
-    lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))  # `transpose` must before `cconvert`!
-    positions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
+    clattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))  # `transpose` must before `cconvert`!
+    cpositions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
     atomtypes = unique(atoms)
-    atoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices
-    if !isempty(magmoms)
-        magmoms = if eltype(magmoms) <: AbstractVector
-            Base.cconvert(Matrix{Cdouble}, reduce(hcat, magmoms))
-        else
-            Base.cconvert(Vector{Cdouble}, magmoms)
-        end
+    catoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices
+    cmagmoms = if eltype(magmoms) <: AbstractVector
+        Base.cconvert(Matrix{Cdouble}, reduce(hcat, magmoms))
+    else
+        Base.cconvert(Vector{Cdouble}, magmoms)  # `magmoms` could be empty!
     end
-    return lattice, positions, atoms, magmoms
+    return clattice, cpositions, catoms, cmagmoms
 end
 function _expand_cell(cell::CrystallographyCell)
     lattice, positions, atoms = cell.lattice, cell.positions, cell.atoms

--- a/src/core.jl
+++ b/src/core.jl
@@ -157,7 +157,7 @@ function _expand_cell(cell::SpglibCell)
     cell.positions, cell.atoms,
     cell.magmoms
     # Reference: https://github.com/mdavezac/spglib.jl/blob/master/src/spglib.jl#L32-L35 and https://github.com/spglib/spglib/blob/444e061/python/spglib/spglib.py#L953-L975
-    lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))   # `transpose` must before `cconvert`!
+    lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))  # `transpose` must before `cconvert`!
     positions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
     atomtypes = unique(atoms)
     atoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices
@@ -172,7 +172,7 @@ function _expand_cell(cell::SpglibCell)
 end
 function _expand_cell(cell::CrystallographyCell)
     lattice, positions, atoms = cell.lattice, cell.positions, cell.atoms
-    lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))   # `transpose` must before `cconvert`!
+    lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))  # `transpose` must before `cconvert`!
     positions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
     atomtypes = unique(atoms)
     atoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices

--- a/src/core.jl
+++ b/src/core.jl
@@ -159,7 +159,8 @@ function _expand_cell(cell::SpglibCell)
     # Reference: https://github.com/mdavezac/spglib.jl/blob/master/src/spglib.jl#L32-L35 and https://github.com/spglib/spglib/blob/444e061/python/spglib/spglib.py#L953-L975
     lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))   # `transpose` must before `cconvert`!
     positions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
-    atoms = collect(Cint, findfirst(isequal(u), unique(atoms)) for u in atoms)
+    atomtypes = unique(atoms)
+    atoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices
     if !isempty(magmoms)
         magmoms = if eltype(magmoms) <: AbstractVector
             Base.cconvert(Matrix{Cdouble}, reduce(hcat, magmoms))
@@ -173,7 +174,8 @@ function _expand_cell(cell::CrystallographyCell)
     lattice, positions, atoms = cell.lattice, cell.positions, cell.atoms
     lattice = Base.cconvert(Matrix{Cdouble}, transpose(lattice))   # `transpose` must before `cconvert`!
     positions = Base.cconvert(Matrix{Cdouble}, reduce(hcat, positions))
-    atoms = collect(Cint, findfirst(isequal(u), unique(atoms)) for u in atoms)
+    atomtypes = unique(atoms)
+    atoms = collect(Cint, findfirst(==(atom), atomtypes) for atom in atoms)  # Mapping between unique atom types and atom indices
     return lattice, positions, atoms
 end
 


### PR DESCRIPTION
From 3.395 μs to 475.469 ns