### PR TITLE
Deprecate `convert`, use constructors

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -214,6 +214,31 @@ struct SpacegroupType <: AbstractSpacegroupType
     arithmetic_crystal_class_number::Int32
     arithmetic_crystal_class_symbol::String
 end
+function SpacegroupType(spgtype::SpglibSpacegroupType)
+    international_short = tostring(spgtype.international_short)
+    international_full = tostring(spgtype.international_full)
+    international = tostring(spgtype.international)
+    schoenflies = tostring(spgtype.schoenflies)
+    hall_symbol = tostring(spgtype.hall_symbol)
+    choice = tostring(spgtype.choice)
+    pointgroup_international = tostring(spgtype.pointgroup_international)
+    pointgroup_schoenflies = tostring(spgtype.pointgroup_schoenflies)
+    arithmetic_crystal_class_symbol = tostring(spgtype.arithmetic_crystal_class_symbol)
+    return SpacegroupType(
+        spgtype.number,
+        international_short,
+        international_full,
+        international,
+        schoenflies,
+        spgtype.hall_number,
+        hall_symbol,
+        choice,
+        pointgroup_international,
+        pointgroup_schoenflies,
+        spgtype.arithmetic_crystal_class_number,
+        arithmetic_crystal_class_symbol,
+    )
+end
 
 abstract type AbstractDataset end
 
@@ -313,7 +338,6 @@ See also [`get_dataset`](@ref), [`get_dataset_with_hall_number`](@ref).
     std_mapping_to_primitive::Vector{Int32}
     pointgroup_symbol::String
 end
-
 function Dataset(dataset::SpglibDataset)
     international_symbol = tostring(dataset.international_symbol)
     hall_symbol = tostring(dataset.hall_symbol)
@@ -378,31 +402,6 @@ function Dataset(dataset::SpglibDataset)
         std_rotation_matrix,
         std_mapping_to_primitive,
         pointgroup_symbol,
-    )
-end
-function SpacegroupType(spgtype::SpglibSpacegroupType)
-    international_short = tostring(spgtype.international_short)
-    international_full = tostring(spgtype.international_full)
-    international = tostring(spgtype.international)
-    schoenflies = tostring(spgtype.schoenflies)
-    hall_symbol = tostring(spgtype.hall_symbol)
-    choice = tostring(spgtype.choice)
-    pointgroup_international = tostring(spgtype.pointgroup_international)
-    pointgroup_schoenflies = tostring(spgtype.pointgroup_schoenflies)
-    arithmetic_crystal_class_symbol = tostring(spgtype.arithmetic_crystal_class_symbol)
-    return SpacegroupType(
-        spgtype.number,
-        international_short,
-        international_full,
-        international,
-        schoenflies,
-        spgtype.hall_number,
-        hall_symbol,
-        choice,
-        pointgroup_international,
-        pointgroup_schoenflies,
-        spgtype.arithmetic_crystal_class_number,
-        arithmetic_crystal_class_symbol,
     )
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -314,7 +314,7 @@ See also [`get_dataset`](@ref), [`get_dataset_with_hall_number`](@ref).
     pointgroup_symbol::String
 end
 
-function Base.convert(::Type{Dataset}, dataset::SpglibDataset)
+function Dataset(dataset::SpglibDataset)
     international_symbol = tostring(dataset.international_symbol)
     hall_symbol = tostring(dataset.hall_symbol)
     choice = tostring(dataset.choice)
@@ -380,7 +380,7 @@ function Base.convert(::Type{Dataset}, dataset::SpglibDataset)
         pointgroup_symbol,
     )
 end
-function Base.convert(::Type{SpacegroupType}, spgtype::SpglibSpacegroupType)
+function SpacegroupType(spgtype::SpglibSpacegroupType)
     international_short = tostring(spgtype.international_short)
     international_full = tostring(spgtype.international_full)
     international = tostring(spgtype.international)

--- a/src/magnetic.jl
+++ b/src/magnetic.jl
@@ -197,7 +197,7 @@ function get_magnetic_spacegroup_type_from_symmetry(cell::SpglibCell, symprec=1e
     return convert(MagneticSpacegroupType, spgtype)
 end
 
-function Base.convert(::Type{MagneticDataset}, dataset::SpglibMagneticDataset)
+function MagneticDataset(dataset::SpglibMagneticDataset)
     rotations = transpose.(
         _convert(SMatrix{3,3,Int32}, unsafe_load(dataset.rotations, i)) for
         i in Base.OneTo(dataset.n_operations)

--- a/src/magnetic.jl
+++ b/src/magnetic.jl
@@ -120,6 +120,68 @@ end
     std_rotation_matrix::SMatrix{3,3,Float64,9}
     primitive_lattice::Lattice{Float64}
 end
+function MagneticDataset(dataset::SpglibMagneticDataset)
+    rotations = transpose.(
+        _convert(SMatrix{3,3,Int32}, unsafe_load(dataset.rotations, i)) for
+        i in Base.OneTo(dataset.n_operations)
+    )
+    translations = SVector{3}.(
+        unsafe_load(dataset.translations, i) for i in Base.OneTo(dataset.n_operations)
+    )
+    time_reversals = unsafe_wrap(
+        Vector{Int32}, dataset.time_reversals, dataset.n_operations
+    )
+    equivalent_atoms =  # Need to add 1 because of C-index starts from 0
+        unsafe_wrap(Vector{Int32}, dataset.equivalent_atoms, dataset.n_atoms) .+ 1
+    transformation_matrix = transpose(
+        _convert(SMatrix{3,3,Float64}, dataset.transformation_matrix)
+    )
+    std_lattice = Lattice(transpose(_convert(SMatrix{3,3,Float64}, dataset.std_lattice)))
+    std_types = unsafe_wrap(Vector{Int32}, dataset.std_types, dataset.n_std_atoms)
+    std_positions = SVector{3}.(
+        unsafe_load(dataset.std_positions, i) for i in Base.OneTo(dataset.n_std_atoms)
+    )
+    std_tensors = if iszero(dataset.tensor_rank)  # Collinear spin
+        unsafe_wrap(Vector{Float64}, dataset.std_tensors, dataset.n_std_atoms)
+    else  # Non-collinear spin
+        SVector{3}.(
+            eachcol(
+                unsafe_wrap(
+                    Matrix{Float64},
+                    dataset.std_tensors,
+                    (3, Int64(dataset.n_std_atoms)),  # Issue to Julia community
+                ),
+            ),
+        )
+    end
+    std_rotation_matrix = transpose(
+        _convert(SMatrix{3,3,Float64}, dataset.std_rotation_matrix)
+    )
+    primitive_lattice = Lattice(
+        transpose(_convert(SMatrix{3,3,Float64}, dataset.primitive_lattice))
+    )
+    return MagneticDataset(
+        dataset.uni_number,
+        dataset.msg_type,
+        dataset.hall_number,
+        dataset.tensor_rank,
+        dataset.n_operations,
+        rotations,
+        translations,
+        time_reversals,
+        dataset.n_atoms,
+        equivalent_atoms,
+        transformation_matrix,
+        dataset.origin_shift,
+        dataset.n_std_atoms,
+        std_lattice,
+        std_types,
+        std_positions,
+        std_tensors,
+        std_rotation_matrix,
+        primitive_lattice,
+    )
+end
 
 function get_magnetic_dataset(cell::SpglibCell, symprec=1e-5)
     lattice, positions, atoms, magmoms = _unwrap_convert(cell)
@@ -195,67 +257,4 @@ function get_magnetic_spacegroup_type_from_symmetry(cell::SpglibCell, symprec=1e
     )::SpglibMagneticSpacegroupType
     check_error()
     return convert(MagneticSpacegroupType, spgtype)
-end
-
-function MagneticDataset(dataset::SpglibMagneticDataset)
-    rotations = transpose.(
-        _convert(SMatrix{3,3,Int32}, unsafe_load(dataset.rotations, i)) for
-        i in Base.OneTo(dataset.n_operations)
-    )
-    translations = SVector{3}.(
-        unsafe_load(dataset.translations, i) for i in Base.OneTo(dataset.n_operations)
-    )
-    time_reversals = unsafe_wrap(
-        Vector{Int32}, dataset.time_reversals, dataset.n_operations
-    )
-    equivalent_atoms =  # Need to add 1 because of C-index starts from 0
-        unsafe_wrap(Vector{Int32}, dataset.equivalent_atoms, dataset.n_atoms) .+ 1
-    transformation_matrix = transpose(
-        _convert(SMatrix{3,3,Float64}, dataset.transformation_matrix)
-    )
-    std_lattice = Lattice(transpose(_convert(SMatrix{3,3,Float64}, dataset.std_lattice)))
-    std_types = unsafe_wrap(Vector{Int32}, dataset.std_types, dataset.n_std_atoms)
-    std_positions = SVector{3}.(
-        unsafe_load(dataset.std_positions, i) for i in Base.OneTo(dataset.n_std_atoms)
-    )
-    std_tensors = if iszero(dataset.tensor_rank)  # Collinear spin
-        unsafe_wrap(Vector{Float64}, dataset.std_tensors, dataset.n_std_atoms)
-    else  # Non-collinear spin
-        SVector{3}.(
-            eachcol(
-                unsafe_wrap(
-                    Matrix{Float64},
-                    dataset.std_tensors,
-                    (3, Int64(dataset.n_std_atoms)),  # Issue to Julia community
-                ),
-            ),
-        )
-    end
-    std_rotation_matrix = transpose(
-        _convert(SMatrix{3,3,Float64}, dataset.std_rotation_matrix)
-    )
-    primitive_lattice = Lattice(
-        transpose(_convert(SMatrix{3,3,Float64}, dataset.primitive_lattice))
-    )
-    return MagneticDataset(
-        dataset.uni_number,
-        dataset.msg_type,
-        dataset.hall_number,
-        dataset.tensor_rank,
-        dataset.n_operations,
-        rotations,
-        translations,
-        time_reversals,
-        dataset.n_atoms,
-        equivalent_atoms,
-        transformation_matrix,
-        dataset.origin_shift,
-        dataset.n_std_atoms,
-        std_lattice,
-        std_types,
-        std_positions,
-        std_tensors,
-        std_rotation_matrix,
-        primitive_lattice,
-    )
 end


### PR DESCRIPTION
`convert` means equivalency, however the conversions between `Dataset` & `SpglibDataset`, etc., are not bidirectional