### PR TITLE
Restrict spglib_jll.jl to up to 2.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ CrystallographyCore = "0.1, 0.2, 0.3"
 StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1.0"
 StructEquality = "1, 2"
 julia = "1.3"
-spglib_jll = "2"
+spglib_jll = "2 - 2.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,4 +1,4 @@
-@test get_version() == v"2.2.0"
+@test get_version() == v"2.1.0"
 
 @testset "Constructors" begin
     lattice = [


### PR DESCRIPTION
We will re-enable 2.2.0 on 0.10.0